### PR TITLE
feat: Add 2x2x2x2 puzzle

### DIFF
--- a/MC4D/src/main/res/layout/main.xml
+++ b/MC4D/src/main/res/layout/main.xml
@@ -50,31 +50,52 @@
                 android:textColor="@color/ss_text"
                 android:text="@string/_4d_rotate" />
         </RadioGroup>
-        <TableLayout android:id="@+id/buttons"
-            android:visibility="gone"
+
+        <TableLayout
+            android:id="@+id/buttons"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:layout_width="wrap_content" android:layout_height="wrap_content"
-            android:stretchColumns="1">
+            android:stretchColumns="1"
+            android:visibility="gone">
+
             <TableRow>
-                <Button android:id="@+id/scramble_1" android:text="Scram 1"
+
+                <Button
+                    android:id="@+id/scramble_1"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
+                    android:layout_height="wrap_content"
+                    android:text="Scram 1" />
             </TableRow>
+
             <TableRow>
-                <Button android:id="@+id/scramble_2" android:text="Scram 2"
+
+                <Button
+                    android:id="@+id/scramble_2"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
-                <Button android:id="@+id/scramble_full" android:text="Scram Full"
+                    android:layout_height="wrap_content"
+                    android:text="Scram 2" />
+
+                <Button
+                    android:id="@+id/scramble_full"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
+                    android:layout_height="wrap_content"
+                    android:text="Scram Full" />
             </TableRow>
+
             <TableRow>
-                <Button android:id="@+id/scramble_3" android:text="Scram 3"
+
+                <Button
+                    android:id="@+id/scramble_3"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
-                <Button android:id="@+id/solve" android:text="Solve"
+                    android:layout_height="wrap_content"
+                    android:text="Scram 3" />
+
+                <Button
+                    android:id="@+id/solve"
                     android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
+                    android:layout_height="wrap_content"
+                    android:text="Solve" />
             </TableRow>
         </TableLayout>
     </LinearLayout>

--- a/MC4D/src/main/res/menu/about.xml
+++ b/MC4D/src/main/res/menu/about.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu
-  xmlns:android="http://schemas.android.com/apk/res/android">
-<item android:title="About..." android:id="@+id/item01" android:icon="@android:drawable/ic_menu_info_details"></item>
-</menu>

--- a/MC4D/src/main/res/menu/full.xml
+++ b/MC4D/src/main/res/menu/full.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu
-  xmlns:android="http://schemas.android.com/apk/res/android">
-<item android:title="Scramble Fully" android:id="@+id/item05"></item>
-</menu>

--- a/MC4D/src/main/res/menu/main.xml
+++ b/MC4D/src/main/res/menu/main.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:title="@string/puzzle">
+        <menu>
+            <item
+                android:title="@string/_2_4"
+                android:id="@+id/itemPuzzle2222" />
+            <item
+                android:title="@string/_3_4"
+                android:id="@+id/itemPuzzle3333" />
+        </menu>
+    </item>
+    <item android:title="@string/scramble">
+        <menu>
+            <item
+                android:title="@string/scramble_1"
+                android:id="@+id/itemScramble1" />
+            <item
+                android:title="@string/scramble_2"
+                android:id="@+id/itemScramble2" />
+            <item
+                android:title="@string/scramble_3"
+                android:id="@+id/itemScramble3" />
+            <item
+                android:title="@string/scramble_fully"
+                android:id="@+id/itemScrambleFull" />
+        </menu>
+    </item>
+    <item
+        android:title="@string/solve"
+        android:id="@+id/itemSolve" />
+    <item
+        android:title="@string/send_log"
+        android:id="@+id/itemSendLog" />
+    <item
+        android:title="@string/about"
+        android:id="@+id/itemAbout"
+        android:icon="@android:drawable/ic_menu_info_details" />
+</menu>

--- a/MC4D/src/main/res/menu/scramble1.xml
+++ b/MC4D/src/main/res/menu/scramble1.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu
-  xmlns:android="http://schemas.android.com/apk/res/android">
-<item android:title="Scramble 1" android:id="@+id/item02"></item>
-</menu>

--- a/MC4D/src/main/res/menu/scramble2.xml
+++ b/MC4D/src/main/res/menu/scramble2.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu
-  xmlns:android="http://schemas.android.com/apk/res/android">
-<item android:title="Scramble 2" android:id="@+id/item03"></item>
-</menu>

--- a/MC4D/src/main/res/menu/scramble3.xml
+++ b/MC4D/src/main/res/menu/scramble3.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu
-  xmlns:android="http://schemas.android.com/apk/res/android">
-<item android:title="Scramble 3" android:id="@+id/item04"></item>
-</menu>

--- a/MC4D/src/main/res/menu/send.xml
+++ b/MC4D/src/main/res/menu/send.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu
-  xmlns:android="http://schemas.android.com/apk/res/android">
-<item android:title="Send Log" android:id="@+id/item07"></item>
-</menu>

--- a/MC4D/src/main/res/menu/solve.xml
+++ b/MC4D/src/main/res/menu/solve.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<menu
-  xmlns:android="http://schemas.android.com/apk/res/android">
-<item android:title="Solve" android:id="@+id/item06"></item>
-</menu>

--- a/MC4D/src/main/res/values/strings.xml
+++ b/MC4D/src/main/res/values/strings.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="hello">Hello World, MC4DAndroid!</string>
     <string name="app_name">Magic Cube 4D</string>
     <string name="twist">" Twist"</string>
     <string name="_3d_rotate">" 3D Rotate"</string>
     <string name="_4d_rotate">" 4D Rotate"</string>
+    <string name="about">About…</string>
+    <string name="scramble_fully">Full Scramble</string>
+    <string name="scramble_1">1 Twist</string>
+    <string name="scramble_2">2 Twists</string>
+    <string name="scramble_3">3 Twists</string>
+    <string name="send_log">Send Log</string>
+    <string name="solve">Solve</string>
+    <string name="scramble">Scramble</string>
+    <string name="_2_4">2^4</string>
+    <string name="_3_4">3^4</string>
+    <string name="puzzle">Puzzle</string>
+    <string name="yes">Yes</string>
+    <string name="no">No</string>
+    <string name="change_puzzle_warning">The puzzle state will be cleared if you change the puzzle! Proceed to change puzzle?</string>
 </resources>


### PR DESCRIPTION
## Changes

This PR collapses the scramble options into a submenu, and adds a new submenu for Puzzles. The Puzzles submenu currently only includes the 2x2x2x2 and the 3x3x3x3. Clicking on either entry results in a yes/no dialog showing up and warning the user that their progress will be cleared. Upon pressing "no", the dialog closes and nothing happens. Upon pressing "yes", the puzzle changes to the option clicked on by the user, and the puzzle state resets.

## Demo

![Screencap of switching from the 3x3x3x3 to the 2x2x2x2 on an emulated Android device](https://user-images.githubusercontent.com/7199958/220241099-2943f329-d141-433f-96fb-da20a375a2ae.gif)
